### PR TITLE
Add support for specific http methods annotation

### DIFF
--- a/src/test/java/org/coldis/library/test/service/client/TestService.java
+++ b/src/test/java/org/coldis/library/test/service/client/TestService.java
@@ -15,6 +15,8 @@ import org.springframework.jms.annotation.JmsListener;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -107,7 +109,7 @@ public class TestService {
 	 * @param  test6 Test parameter.
 	 * @return       Test object.
 	 */
-	@RequestMapping(path = "22",  method = RequestMethod.PUT)
+	@PutMapping(path = "22")
 	public DtoTestObject test22(
 			@RequestBody
 			final DtoTestObject test1,
@@ -186,9 +188,8 @@ public class TestService {
 	 * @param test Test argument.
 	 */
 	@Transactional
-	@RequestMapping(
-			path = "test5",
-			method = RequestMethod.PUT
+	@PostMapping(
+			path = "test5"
 	)
 	public void test5(
 			@RequestBody

--- a/src/test/java/org/coldis/library/test/service/client/TestServiceClient.java
+++ b/src/test/java/org/coldis/library/test/service/client/TestServiceClient.java
@@ -524,7 +524,7 @@ java.lang.Long test
 		// Operation parameters.
 		StringBuilder path = new StringBuilder(this.valueResolver
 				.resolveStringValue("http://localhost:8080/test" + (StringUtils.isBlank("test5") ? "" : "/test5") + "?"));
-		final HttpMethod method = HttpMethod.PUT;
+		final HttpMethod method = HttpMethod.POST;
 		final MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
 		Object body = null;
 		final Map<String, Object> uriParameters = new HashMap<>();


### PR DESCRIPTION
This PR adds support for specific `RequestMapping` annotation, such as `GetMapping`, `PostMapping`, `PutMapping`, `PatchMapping` and `DeleteMapping`.